### PR TITLE
Minor Enhancements: Username in auction info, Auction embedcolor and Current bid in outbid message.

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -80,7 +80,7 @@ class Auctions(commands.Cog):
         embed.title = "[SOLD] " + embed.title
         auction_info = (
             f"**Winning Bid:** {auction.current_bid:,} Pokécoins",
-            f"**Bidder:** {bidder.mention}",
+            f"**Bidder:** {bidder} {bidder.mention}",
         )
         embed.add_field(name="Auction Details", value="\n".join(auction_info))
         embed.set_footer(text=f"The auction has ended.")
@@ -130,7 +130,7 @@ class Auctions(commands.Cog):
                 print("Error trading auction logs.")
 
     def make_base_embed(self, author, pokemon, auction_id):
-        embed = discord.Embed(color=0xFE9AC9)
+        embed = discord.Embed(color=pokemon.color or 0xFE9AC9)
         embed.set_author(name=str(author), icon_url=author.avatar_url)
         embed.title = f"Auction #{auction_id} • {pokemon:ln}"
 
@@ -417,7 +417,7 @@ class Auctions(commands.Cog):
 
             auction_info = (
                 f"**Current Bid:** {bid:,} Pokécoins",
-                f"**Bidder:** {ctx.author.mention}",
+                f"**Bidder:** {ctx.author} {ctx.author.mention}",
                 f"**Bid Increment:** {auction.bid_increment:,} Pokécoins",
             )
             embed.add_field(name="Auction Details", value="\n".join(auction_info))
@@ -460,7 +460,7 @@ class Auctions(commands.Cog):
                 self.bot.loop.create_task(
                     self.bot.http.send_message(
                         priv["id"],
-                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** (Auction #{auction.id}).",
+                        f"You have been outbid on the **{auction.pokemon.iv_percentage:.2%} {auction.pokemon.species}** with a Current bid of **{auction.current_bid:,}** Pokécoins (Auction #{auction.id}).",
                     )
                 )
             self.bot.loop.create_task(
@@ -605,7 +605,7 @@ class Auctions(commands.Cog):
 
             auction_info = (
                 f"**Current Bid:** {auction.current_bid:,} Pokécoins",
-                f"**Bidder:** {bidder.mention}",
+                f"**Bidder:** {bidder} {bidder.mention}",
                 f"**Bid Increment:** {auction.bid_increment:,} Pokécoins",
             )
         embed.add_field(name="Auction Details", value="\n".join(auction_info))

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -308,7 +308,7 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
 
-    # Rename all
+    # Favorite all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.user)
     @flags.command(
@@ -406,7 +406,7 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--skip", type=int)
     @flags.add_flag("--limit", type=int)
 
-    # Rename all
+    # Unfavorite all
     @checks.has_started()
     @commands.max_concurrency(1, commands.BucketType.user)
     @flags.command(


### PR DESCRIPTION
- Shows current bidder's **username#discriminator** along with the mention. (Mentions previously mostly showed @invalid_user on mobile and <@ id> on PC, wasn't as useful.)
- Auction infos' embed color now corresponds with the embed color of the pokemon if it has an embedcolor.
- Shows current bid in outbid message.