### PR TITLE
Catch Mentions

### DIFF
--- a/cogs/mongo.py
+++ b/cogs/mongo.py
@@ -278,7 +278,8 @@ class Member(Document):
     # Settings
     show_balance = fields.BooleanField(default=True)
     silence = fields.BooleanField(default=False)
-
+    catch_mention = fields.BooleanField(default=True)
+    
     # Quests
     badges = fields.DictField(fields.StringField(), fields.BooleanField(), default=dict)
     quest_progress = fields.DictField(fields.StringField(), fields.IntegerField(), default=dict)

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -399,7 +399,7 @@ class Spawning(commands.Cog):
         if shiny:
             await self.bot.mongo.update_member(ctx.author, {"$inc": {"shinies_caught": 1}})
 
-        message = f"Congratulations {ctx.author.mention}! You caught a level {level} {species}!"
+        message = f"Congratulations {ctx.author.mention if member.catch_mention else ctx.author.display_name}! You caught a level {level} {species}!"
 
         memberp = await self.bot.mongo.fetch_pokedex(
             ctx.author, species.dex_number, species.dex_number + 1
@@ -461,7 +461,22 @@ class Spawning(commands.Cog):
 
         self.bot.dispatch("catch", ctx, species)
         await ctx.send(message)
+        
+    @checks.has_started()
+    @commands.command(aliases=("tm",))
+    async def togglemention(self, ctx):
+        """Toggle getting mentioned when catching a pokémon."""
+        member = await self.bot.mongo.fetch_member_info(ctx.author)
 
+        await self.bot.mongo.update_member(
+            ctx.author, {"$set": {"catch_mention": not member.catch_mention}}
+        )
+
+        if member.catch_mention:
+            await ctx.send(f"You will no longer receive catch pings.")
+        else:
+            await ctx.send("You will now be pinged on catches.")
+    
     @checks.has_started()
     @commands.command(aliases=("sh",))
     async def shinyhunt(self, ctx, *, species: str = None):

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -463,7 +463,7 @@ class Spawning(commands.Cog):
         await ctx.send(message)
         
     @checks.has_started()
-    @commands.command(aliases=("tm",))
+    @commands.command()
     async def togglemention(self, ctx):
         """Toggle getting mentioned when catching a pokémon."""
         member = await self.bot.mongo.fetch_member_info(ctx.author)


### PR DESCRIPTION
- Allow toggling on whether you will get pinged when catching a pokémon.
- To toggle: p!togglemention
   - This command works in a similar way to p!togglebal