### PR TITLE
Catch mention bug

### DIFF
--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -398,8 +398,10 @@ class Spawning(commands.Cog):
         )
         if shiny:
             await self.bot.mongo.update_member(ctx.author, {"$inc": {"shinies_caught": 1}})
-
-        message = f"Congratulations {ctx.author.mention if member.catch_mention else ctx.author.display_name}! You caught a level {level} {species}!"
+            
+        first_step = discord.utils.escape_markdown(ctx.author.display_name)
+        catch_name = first_step.replace("<", "\\<")
+        message = f"Congratulations {ctx.author.mention if member.catch_mention else catch_name}! You caught a level {level} {species}!"
 
         memberp = await self.bot.mongo.fetch_pokedex(
             ctx.author, species.dex_number, species.dex_number + 1


### PR DESCRIPTION
**Fixed bug reported by 11pixels#2004 on discord where:**
If you had catch mentions turned off and set your nick to `<@ID>` where **ID** is the ID of a person, it would just ping that person when you catch a pokemon.

Fix:
Made it so it escapes markdown for the nickname. This way not only does it fix the ping issue, it also shows the actual nickname instead of marking down incase the nickname has markdown symbols (for example it would italic the name if my name had * at each end. )