### PR TITLE
Add item filter flag

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -477,7 +477,8 @@ class Auctions(commands.Cog):
     @flags.add_flag("--name", "--n", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -34,7 +34,8 @@ class Market(commands.Cog):
     @flags.add_flag("--name", "--n", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -109,7 +109,8 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")
@@ -288,7 +289,8 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")
@@ -386,7 +388,8 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")
@@ -634,6 +637,17 @@ class Pokemon(commands.Cog):
         if "region" in flags and flags["region"]:
             all_species = [i for x in flags["region"] for i in self.bot.data.list_region(x)]
             aggregations.append({"$match": {"pokemon.species_id": {"$in": all_species}}})
+       
+        if "item" in flags and flags["item"] is not None:
+            if not any(flags["item"]):
+                aggregations.append({"$match": {"pokemon.held_item": {"$type": "number"}}})
+            else:
+                all_items = list(
+                    filter(
+                        None, map(lambda x: getattr(self.bot.data.item_by_name(" ".join(x)), "id", None), flags["item"])
+                    )
+                )
+                aggregations.append({"$match": {"pokemon.held_item": {"$in": all_items}}})
 
         if "favorite" in flags and flags["favorite"]:
             aggregations.append({"$match": {"pokemon.favorite": True}})
@@ -818,7 +832,8 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")
@@ -928,7 +943,8 @@ class Pokemon(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -642,11 +642,7 @@ class Pokemon(commands.Cog):
             if not any(flags["item"]):
                 aggregations.append({"$match": {"pokemon.held_item": {"$type": "number"}}})
             else:
-                all_items = list(
-                    filter(
-                        None, map(lambda x: getattr(self.bot.data.item_by_name(" ".join(x)), "id", None), flags["item"])
-                    )
-                )
+                all_items = [i for i in (getattr(self.bot.data.item_by_name(" ".join(x)), "id", None) for x in flags["item"]) if i is not None]
                 aggregations.append({"$match": {"pokemon.held_item": {"$in": all_items}}})
 
         if "favorite" in flags and flags["favorite"]:

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -636,7 +636,8 @@ class Trading(commands.Cog):
     @flags.add_flag("--nickname", nargs="+", action="append")
     @flags.add_flag("--type", "--t", type=str, action="append")
     @flags.add_flag("--region", "--r", type=str, action="append")
-
+    @flags.add_flag("--item", nargs="*", action="append")
+    
     # IV
     @flags.add_flag("--level", nargs="+", action="append")
     @flags.add_flag("--hpiv", nargs="+", action="append")


### PR DESCRIPTION
## Feature for #255 
### Usage:
- Flag: —item
- If there are no arguments for —item, all Pokémon with a held item are given. 
- Examples:
    - p!p —item
    - p!p —item everstone