### PR TITLE
fix issues with auctions ending before you finish bidding

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -1,5 +1,5 @@
 import asyncio
-import collections
+from collections import defaultdict
 from itertools import starmap
 
 from discord.errors import HTTPException
@@ -36,7 +36,7 @@ class Auctions(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.check_auctions.start()
-        self.locks = collections.defaultdict(asyncio.Lock)
+        self.locks = defaultdict(asyncio.Lock)
 
     @tasks.loop(minutes=1)
     async def check_auctions(self):


### PR DESCRIPTION
This pr replaces the` asyncio.Semaphore(1)`(which is actually the same as an asyncio.Lock) an defaultdict of asyncio.Locks, which will use the guild id as the key.

This is good once auctions is released to multiple guilds, since auctions from different guilds shouldn't conflict.

This pr also adds a lock to the ending auction process, which should fix issues with you losing money but not winning the auction.