### PR TITLE
Fixed bug allowing you to buy nature mint that your pokemon already has.

### DIFF
--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -827,6 +827,9 @@ class Shop(commands.Cog):
         if "nature" in item.action:
             idx = int(item.action.split("_")[1])
 
+            if pokemon.nature == constants.NATURES[idx]:
+                return await ctx.send(f"Your selected pokémon's nature is already {constants.NATURES[idx]}!")
+
             await self.bot.mongo.update_pokemon(
                 pokemon, {"$set": {"nature": constants.NATURES[idx]}}
             )


### PR DESCRIPTION
This PR fixes a bug reported by Var_Monke#1354 on discord which allows you to be able to buy nature mint the same as your selected pokemons' nature.