### PR TITLE
Changed all instances of `p!` to `{ctx.prefix}` to make the messages more dynamic

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -207,7 +207,7 @@ class Auctions(commands.Cog):
             or (auction_channel := ctx.guild.get_channel(guild.auction_channel)) is None
         ):
             return await ctx.send(
-                "Auctions have not been set up in this server. Have a server administrator do `p!auction channel #channel`."
+                f"Auctions have not been set up in this server. Have a server administrator do `{ctx.prefix}auction channel #channel`."
             )
 
         member = await self.bot.mongo.fetch_member_info(ctx.author)

--- a/cogs/battling.py
+++ b/cogs/battling.py
@@ -439,7 +439,7 @@ class Battling(commands.Cog):
         embed = self.bot.Embed(title=f"What should {species} do?")
 
         embed.description = "\n".join(
-            f"{k} **{v['text']}** • `{ctx.prefix}!battle move {v['command']}`" for k, v in actions.items()
+            f"{k} **{v['text']}** • `p!battle move {v['command']}`" for k, v in actions.items()
         )
         msg = await self.bot.send_dm(user_id, embed=embed)
 

--- a/cogs/battling.py
+++ b/cogs/battling.py
@@ -439,7 +439,7 @@ class Battling(commands.Cog):
         embed = self.bot.Embed(title=f"What should {species} do?")
 
         embed.description = "\n".join(
-            f"{k} **{v['text']}** • `p!battle move {v['command']}`" for k, v in actions.items()
+            f"{k} **{v['text']}** • `{ctx.prefix}!battle move {v['command']}`" for k, v in actions.items()
         )
         msg = await self.bot.send_dm(user_id, embed=embed)
 

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -227,7 +227,7 @@ class Pokemon(commands.Cog):
 
                 if pokemon.favorite:
                     messages.append(
-                        f"Your level {pokemon.level} {name} is already favorited.\nTo unfavorite a pokemon, please use `p!unfavorite`."
+                        f"Your level {pokemon.level} {name} is already favorited.\nTo unfavorite a pokemon, please use `{ctx.prefix}unfavorite`."
                     )
                 else:
                     await self.bot.mongo.update_pokemon(

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -611,7 +611,7 @@ class Shop(commands.Cog):
                 )
 
             await ctx.send(
-                f"You purchased {item.name}! Use `{ctx.prefix}!shop` to check how much time you have remaining."
+                f"You purchased {item.name}! Use `{ctx.prefix}shop` to check how much time you have remaining."
             )
 
         elif item.action == "shard":

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -647,7 +647,7 @@ class Shop(commands.Cog):
                 )
 
             await ctx.send(
-                f"You purchased a {item.name}! Use `{ctx.prefix}!shop` to check how much time you have remaining."
+                f"You purchased a {item.name}! Use `{ctx.prefix}shop` to check how much time you have remaining."
             )
 
         elif item.action == "incense":

--- a/cogs/shop.py
+++ b/cogs/shop.py
@@ -611,7 +611,7 @@ class Shop(commands.Cog):
                 )
 
             await ctx.send(
-                f"You purchased {item.name}! Use `p!shop` to check how much time you have remaining."
+                f"You purchased {item.name}! Use `{ctx.prefix}!shop` to check how much time you have remaining."
             )
 
         elif item.action == "shard":
@@ -647,7 +647,7 @@ class Shop(commands.Cog):
                 )
 
             await ctx.send(
-                f"You purchased a {item.name}! Use `p!shop` to check how much time you have remaining."
+                f"You purchased a {item.name}! Use `{ctx.prefix}!shop` to check how much time you have remaining."
             )
 
         elif item.action == "incense":

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -467,7 +467,7 @@ class Spawning(commands.Cog):
                 name=f"Currently Hunting",
                 value=self.bot.data.species_by_number(member.shiny_hunt).name
                 if member.shiny_hunt
-                else f"Type `{ctx.prefix}!shinyhunt <pokémon>` to begin!",
+                else f"Type `{ctx.prefix}shinyhunt <pokémon>` to begin!",
             )
 
             if member.shiny_hunt:

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -467,7 +467,7 @@ class Spawning(commands.Cog):
                 name=f"Currently Hunting",
                 value=self.bot.data.species_by_number(member.shiny_hunt).name
                 if member.shiny_hunt
-                else "Type `p!shinyhunt <pokémon>` to begin!",
+                else f"Type `{ctx.prefix}!shinyhunt <pokémon>` to begin!",
             )
 
             if member.shiny_hunt:


### PR DESCRIPTION
In some commands, the bot refers to `p!` as a prefix whereas the prefix for that particular guild or the prefix used by the user might not be `p!`.
For example, this:
![Example](https://cdn.discordapp.com/attachments/808404030380441600/909733678287040532/Screenshot_2021-11-15_at_2.44.34_PM.png)
I use `-` as a prefix but poketwo refers to `p!` as a prefix, even though `p!` is not a prefix in this guild.
This PR changes that, and poketwo will refer to whatever prefix the author is using as the prefix in its messages.