### PR TITLE
Remove the top.gg button from the Christmas Event's Embed

### DIFF
--- a/cogs/christmas_2021.py
+++ b/cogs/christmas_2021.py
@@ -84,7 +84,7 @@ class Christmas(commands.Cog):
             inline=False,
         )
 
-        await ctx.send(embed=embed, view=view)
+        await ctx.send(embed=embed)
 
     @commands.check_any(commands.is_owner(), commands.has_role(718006431231508481))
     @christmas.command(aliases=("givebox", "ab", "gb"))

--- a/cogs/christmas_2021.py
+++ b/cogs/christmas_2021.py
@@ -84,13 +84,6 @@ class Christmas(commands.Cog):
             inline=False,
         )
 
-        view = discord.ui.View()
-        view.add_item(
-            discord.ui.Button(
-                label="Visit Top.gg", url="https://top.gg/bot/716390085896962058/vote"
-            )
-        )
-
         await ctx.send(embed=embed, view=view)
 
     @commands.check_any(commands.is_owner(), commands.has_role(718006431231508481))


### PR DESCRIPTION
This PR removes the button which directs users to [top.gg](https://top.gg/bot/716390085896962058/vote) , which isn't required in this case.