### PR TITLE
Make it possible to use +/- to order ascending/descending.

### DIFF
--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -540,7 +540,7 @@ class Pokemon(commands.Cog):
         sort = sort.lower()
 
         if sort not in [a + b for a in ("number", "iv", "level", "pokedex") for b in ("+", "-", "")]:
-            return await ctx.send(f"Please specify either `iv`, `iv+`, `iv-`, `level`, `level+`, `level-`, `number`, `number+`, `number-`, `pokedex`, `pokedex+` or `pokedex-`")
+            return await ctx.send("Please specify either `iv`, `iv+`, `iv-`, `level`, `level+`, `level-`, `number`, `number+`, `number-`, `pokedex`, `pokedex+` or `pokedex-`")
 
         await self.bot.mongo.update_member(
             ctx.author,

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -540,7 +540,7 @@ class Pokemon(commands.Cog):
         sort = sort.lower()
 
         if sort not in [a + b for a in ("number", "iv", "level", "pokedex") for b in ("+", "-", "")]:
-            return await ctx.send("Please specify either `number`, `IV`, `level`, or `pokedex`.")
+            return await ctx.send(f"Invalid choice. Please specify `iv`, `iv+`, `iv-`, `level`, `level+`, `level-`, `number`, `number+`, `number-`, `pokedex`, `pokedex+` or `pokedex-`")
 
         await self.bot.mongo.update_member(
             ctx.author,

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -540,7 +540,7 @@ class Pokemon(commands.Cog):
         sort = sort.lower()
 
         if sort not in [a + b for a in ("number", "iv", "level", "pokedex") for b in ("+", "-", "")]:
-            return await ctx.send(f"Invalid choice. Please specify `iv`, `iv+`, `iv-`, `level`, `level+`, `level-`, `number`, `number+`, `number-`, `pokedex`, `pokedex+` or `pokedex-`")
+            return await ctx.send(f"Please specify either `iv`, `iv+`, `iv-`, `level`, `level+`, `level-`, `number`, `number+`, `number-`, `pokedex`, `pokedex+` or `pokedex-`")
 
         await self.bot.mongo.update_member(
             ctx.author,

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -539,7 +539,7 @@ class Pokemon(commands.Cog):
 
         sort = sort.lower()
 
-        if sort not in ("number", "iv", "level", "pokedex"):
+        if sort not in [a + b for a in ("number", "iv", "level", "pokedex") for b in ("+", "-", "")]:
             return await ctx.send("Please specify either `number`, `IV`, `level`, or `pokedex`.")
 
         await self.bot.mongo.update_member(


### PR DESCRIPTION
Suggested in #108, this PR (hopefully) makes it possible to sort p!pokemon ascending/descending in the same way as the order filter for market search and auction search.