### PR TITLE
Disallow bidding on auctions while in trade

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -320,6 +320,7 @@ class Auctions(commands.Cog):
         await ctx.send(f"Lowered the starting bid on your auction to **{new_start:,} Pokécoins**.")
 
     @checks.has_started()
+    @checks.is_not_in_trade()
     @commands.max_concurrency(1, per=commands.BucketType.user)
     @auction.command(aliases=("b",))
     async def bid(self, ctx, auction: AuctionConverter, bid: int):


### PR DESCRIPTION
Similar to buying from market, it should not be possible to bid while in a trade. This is potentially abusable.