### PR TITLE
Add the suspension check to commands where it was missing

### DIFF
--- a/cogs/battling.py
+++ b/cogs/battling.py
@@ -762,7 +762,6 @@ class Battling(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @checks.has_started()
     @in_battle(True)
     @battle.command(aliases=("x",))
     async def cancel(self, ctx):

--- a/cogs/battling.py
+++ b/cogs/battling.py
@@ -500,9 +500,15 @@ class Battling(commands.Cog):
         if user in self.bot.battles:
             return await ctx.send(f"**{user}** is already in a battle!")
 
-        member = await self.bot.mongo.Member.find_one({"id": user.id})
+        member = await ctx.bot.mongo.Member.find_one(
+            {"id": user.id}, {"suspended": 1, "suspension_reason": 1}
+        )
+        
         if member is None:
             return await ctx.send("That user hasn't picked a starter pokémon yet!")
+
+        if member.suspended:
+            return await ctx.send(f"**{member}** is suspended from the bot!")
 
         # Challenge to battle
 

--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -29,6 +29,7 @@ class Pokemon(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
+    @checks.has_started()
     @commands.command(aliases=("renumber",))
     async def reindex(self, ctx):
         """Re-number all pokémon in your collection."""
@@ -53,6 +54,7 @@ class Pokemon(commands.Cog):
         await self.bot.mongo.db.pokemon.bulk_write(ops)
         await ctx.send("Successfully reindexed all your pokémon!")
 
+    @checks.has_started()
     @commands.command(aliases=("nick",))
     async def nickname(
         self,
@@ -187,6 +189,7 @@ class Pokemon(commands.Cog):
         else:
             await ctx.send(f"Changed nickname to `{nicknameall}` for {num} pokémon.")
 
+    @checks.has_started()
     @commands.command(
         aliases=(
             "favourite",
@@ -227,6 +230,7 @@ class Pokemon(commands.Cog):
             for i in range(0, len(longmsg), 2000):
                 await ctx.send(longmsg[i : i + 2000])
 
+    @checks.has_started()
     @commands.command(
         aliases=(
             "unfavourite",
@@ -1218,6 +1222,7 @@ class Pokemon(commands.Cog):
 
         await ctx.send("Successfully switched back to non-mega form.")
 
+    @checks.has_started()
     @commands.command(aliases=("f",))
     async def first(self, ctx):
         if ctx.author.id not in self.bot.menus:
@@ -1228,6 +1233,7 @@ class Pokemon(commands.Cog):
             await pages.message.clear_reactions()
         await pages.continue_at(ctx, 0)
 
+    @checks.has_started()
     @commands.command(aliases=("n", "forward"))
     async def next(self, ctx):
         if ctx.author.id not in self.bot.menus:
@@ -1238,6 +1244,7 @@ class Pokemon(commands.Cog):
             await pages.message.clear_reactions()
         await pages.continue_at(ctx, pages.current_page + 1)
 
+    @checks.has_started()
     @commands.command(aliases=("prev", "back", "b"))
     async def previous(self, ctx):
         if ctx.author.id not in self.bot.menus:
@@ -1252,6 +1259,7 @@ class Pokemon(commands.Cog):
             await pages.message.clear_reactions()
         await pages.continue_at(ctx, pages.current_page - 1)
 
+    @checks.has_started()
     @commands.command(aliases=("l",))
     async def last(self, ctx):
         if ctx.author.id not in self.bot.menus:
@@ -1266,6 +1274,7 @@ class Pokemon(commands.Cog):
             await pages.message.clear_reactions()
         await pages.continue_at(ctx, pages._source.get_max_pages() - 1)
 
+    @checks.has_started()
     @commands.command(aliases=("page", "g"))
     async def go(self, ctx, page: int):
         if ctx.author.id not in self.bot.menus:

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -377,7 +377,6 @@ class Trading(commands.Cog):
         await self.bot.redis.hset("trade", user.id, self.bot.cluster_idx)
         await self.send_trade(ctx, ctx.author)
 
-    @checks.has_started()
     @commands.guild_only()
     @trade.command(aliases=("x",))
     async def cancel(self, ctx):

--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -332,10 +332,15 @@ class Trading(commands.Cog):
         if await self.is_in_trade(user):
             return await ctx.send(f"**{user}** is already in a trade!")
 
-        member = await self.bot.mongo.Member.find_one({"id": user.id})
-
+        member = await ctx.bot.mongo.Member.find_one(
+            {"id": user.id}, {"suspended": 1, "suspension_reason": 1}
+        )
+        
         if member is None:
             return await ctx.send("That user hasn't picked a starter pokémon yet!")
+
+        if member.suspended:
+            return await ctx.send(f"**{member}** is suspended from the bot!")
 
         message = await ctx.send(f"Requesting a trade with {user.mention}. Click the checkmark to accept!")
         await message.add_reaction("✅")


### PR DESCRIPTION
### Changes
- Adds the suspension check to a few commands which did not have it, allowing suspended users to use those commands (e.g. favorite)
- Prevents users from requesting battles/trades from suspended users
- Allows suspended users to cancel battles/trades (for cases where they msy have been suspended while in one