### PR TITLE
Fix config.py

### DIFF
--- a/cogs/config.py
+++ b/cogs/config.py
@@ -21,7 +21,7 @@ class Configuration(commands.Cog):
 
         embed = self.bot.Embed(title="Server Configuration")
         
-        if ctx.guild.icon:
+        if ctx.guild.icon is not None:
             embed.set_thumbnail(url=ctx.guild.icon.url)
             
         embed.add_field(

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -20,7 +20,10 @@ class Configuration(commands.Cog):
         prefix = guild.prefix if guild.prefix is not None else "p!"
 
         embed = self.bot.Embed(title="Server Configuration")
-        embed.set_thumbnail(url=ctx.guild.icon.url)
+        
+        if ctx.guild.icon:
+            embed.set_thumbnail(url=ctx.guild.icon.url)
+            
         embed.add_field(
             name=f"Prefix {commands.get('prefix_command', '')}",
             value=f"`{prefix}`",


### PR DESCRIPTION
# Configuration Command Error
When typing `p!configuration` in a server with no icon, the command doesn't work since the below cannot fetch an icon.
```py
embed.set_thumbnail(url=ctx.guild.icon.url)
```
The fix is to add a check to see if the server has a icon.
```py
if ctx.guild.icon:
     embed.set_thumbnail(url=ctx.guild.icon.url)
```
