### PR TITLE
Simple Spelling Error

### DIFF
--- a/cogs/anniversary_2022.py
+++ b/cogs/anniversary_2022.py
@@ -219,7 +219,7 @@ class Anniversary(commands.Cog):
         )
         reset_text = ""
         if member.get("bingos_awarded", 0) == 12:
-            reset_text = f"\nYou have completed the whole board! If you would like to restart, type `{ctx.prefix}!anniversary reset` to get a fresh board and new quests."
+            reset_text = f"\nYou have completed the whole board! If you would like to restart, type `{ctx.prefix}anniversary reset` to get a fresh board and new quests."
         embed.add_field(
             name=f"Your Bingo Board (#{member.get('boards_completed', 0) + 1})",
             value=f"**# Bingos:** {member.get('bingos_awarded', 0)}{reset_text}\n\n" + self.generate_bingo_board(board),


### PR DESCRIPTION
<img width="309" alt="image" src="https://user-images.githubusercontent.com/77411358/173214352-47016504-bcaf-4adc-857c-2f72feee24ac.png">

A really simple spelling mistake which can be fixed by removing `!` next to `ctx.prefix`