### PR TITLE
Bandaid fix for trades breaking due to 1024 character limit when adding pokemon with long names

### DIFF
--- a/cogs/trading.py
+++ b/cogs/trading.py
@@ -150,7 +150,7 @@ class Trading(commands.Cog):
 
                 sign = "🟢" if trade[mem.id] else "🔴"
 
-                embed.add_field(name=f"{sign} {mem.display_name}", value=val)
+                embed.add_field(name=f"{sign} {mem.display_name}", value=val[:1024])
 
             embed.set_footer(
                 text=f"Showing page {pidx + 1} out of {num_pages}.\nReminder: Trading Pokécoins or Pokémon for real-life currencies or items in other bots is prohibited and will result in the suspension of your Pokétwo account!"


### PR DESCRIPTION
Limits the length of the value of users' items fields, to prevent the trade from breaking when adding pokemon with longer names (such as Spring Fever Cubchoo)