### PR TITLE
Prevent suspended user from contributing to spawns

### DIFF
--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -147,6 +147,11 @@ class Spawning(commands.Cog):
             return
 
         ctx = await self.bot.get_context(message)
+        member = await self.bot.mongo.fetch_member_info(message.author)
+
+        if member is not None:
+            if member.suspended:
+                return
 
         if ctx.valid:
             return

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -52,13 +52,8 @@ class Spawning(commands.Cog):
     async def before_spawn_incense(self):
         await self.bot.wait_until_ready()
 
-    async def increase_xp(self, message):
-        member = await self.bot.mongo.fetch_member_info(message.author)
-
+    async def increase_xp(self, message, member):
         if member is not None:
-            if member.suspended:
-                return
-
             silence = member.silence
             if message.guild:
                 guild = await self.bot.mongo.fetch_guild(message.guild)
@@ -149,12 +144,12 @@ class Spawning(commands.Cog):
         ctx = await self.bot.get_context(message)
         member = await self.bot.mongo.fetch_member_info(message.author)
 
+        if ctx.valid:
+            return
+
         if member is not None:
             if member.suspended:
                 return
-
-        if ctx.valid:
-            return
 
         current = time.time()
 
@@ -165,7 +160,7 @@ class Spawning(commands.Cog):
 
         # Increase XP on selected pokemon
 
-        await self.increase_xp(message)
+        await self.increase_xp(message, member)
 
         # Increment guild activity counter
 

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -142,10 +142,11 @@ class Spawning(commands.Cog):
             return
 
         ctx = await self.bot.get_context(message)
-        member = await self.bot.mongo.fetch_member_info(message.author)
-
+        
         if ctx.valid:
             return
+
+        member = await self.bot.mongo.fetch_member_info(message.author)
 
         if member is not None:
             if member.suspended:


### PR DESCRIPTION
This commit makes it so that suspended users' messages do not contribute to spawns. This is an important change in order to prevent autospammers from still working after suspension (which defeats the purpose of suspending autospammers)