### PR TITLE
Add all cog description/command help strings to Fluent

### DIFF
--- a/cogs/lang.py
+++ b/cogs/lang.py
@@ -10,6 +10,8 @@ import structlog
 FLUENT_FILES = (
     "main.ftl",
     "help.ftl",
+    "cogs.ftl",
+    "commands.ftl",
 )
 
 

--- a/lang/en-US/cogs.ftl
+++ b/lang/en-US/cogs.ftl
@@ -1,0 +1,43 @@
+### Localizations for cog descriptions.
+
+cog-market-help =
+  .description = A marketplace to buy and sell {-pokemon}.
+
+cog-pokemon-help =
+  .name = {-pokemon}
+  .description = Commands for managing your {-pokemon}.
+
+cog-pride-help =
+  .description = Pride Month 2023 commands.
+
+cog-quests-help =
+  .description = Quest commands.
+
+cog-shop-help =
+  .description = Shop-related commands.
+
+cog-spawning-help =
+  .description = For basic bot operation.
+
+cog-trading-help =
+  .description = For trading.
+
+cog-administration-help =
+  .description = Commands for bot administration.
+
+cog-auctions-help =
+  .description = For auctions.
+
+cog-battling-help =
+  .description = For battling.
+
+cog-bot-help =
+  .description = For basic bot operation.
+
+cog-configuration-help =
+  .description = Configuration commands to change bot behavior.
+
+# Note: An external cog that provides administration capabilities.
+# "Jishaku" is romanized Japanese for "magnet".
+cog-jishaku-help=
+  .description = Enables rapid prototyping, experimentation, and debugging.

--- a/lang/en-US/commands.ftl
+++ b/lang/en-US/commands.ftl
@@ -176,7 +176,7 @@ command-admin-addbox-help =
   .help = Give a user boxes.
 
 command-admin-tempsuspend-help =
-  .help = Temporarily uspend one or more users.
+  .help = Temporarily suspend one or more users.
 
 command-admin-addcoins-help =
   .help = Add to a user's balance.

--- a/lang/en-US/commands.ftl
+++ b/lang/en-US/commands.ftl
@@ -251,7 +251,7 @@ command-start-help =
   .help = View the starter {-pokemon}.
 
 command-pokedex-help =
-  .help = View your pokédex, or search for a {-pokemon} species.
+  .help = View your {-pokedex}, or search for a {-pokemon} species.
 
 command-pride-help =
   .help = Pride Month 2023 event commands.

--- a/lang/en-US/commands.ftl
+++ b/lang/en-US/commands.ftl
@@ -77,7 +77,7 @@ command-favorite-help =
   .help = Mark a {-pokemon} as a favorite.
 
 command-unfavorite-help =
-  .help = Unfavorite a selected pokemon.
+  .help = Unfavorite a selected {-pokemon}.
 
 command-balance-help =
   .help = View your current balance.
@@ -98,7 +98,7 @@ command-silence-help =
   .help = Silence level up messages for yourself.
 
 command-unfavoriteall-help =
-  .help = Mass unfavorite selected pokemon.
+  .help = Mass unfavorite selected {-pokemon}.
 
 command-quests-help =
   .help = View quests.
@@ -248,7 +248,7 @@ command-togglemention-help =
   .help = Toggle getting mentioned when catching a {-pokemon}.
 
 command-start-help =
-  .help = View the starter {-pokemon}.
+  .help = View the starter {-pokemon-plural}.
 
 command-pokedex-help =
   .help = View your {-pokedex}, or search for a {-pokemon} species.

--- a/lang/en-US/commands.ftl
+++ b/lang/en-US/commands.ftl
@@ -1,0 +1,275 @@
+### Localizations for command help messages (not messages that commands use
+### themselves).
+
+command-help-help =
+  .help = Show help about the bot, a command, or a category.
+
+command-nickname-help =
+  .help = Change the nickname for your {-pokemon}.
+
+command-open-help =
+  .help = Open mystery boxes received from voting.
+
+command-shinyhunt-help =
+  .help = Hunt for a shiny {-pokemon} species.
+
+command-cleanup-help =
+  .help = Cleans up the bot's messages from the channel.
+
+command-redeem-help =
+  .help = Use a redeem to receive a {-pokemon} of your choice.
+
+command-unmega-help =
+  .help = Switch a {-pokemon} back to its non-mega form.
+
+command-profile-help =
+  .help = View your profile.
+
+command-favoriteall-help =
+  .help = Mass favorite selected {-pokemon}.
+
+command-invite-help =
+  .help = View the invite link for the bot.
+
+command-help-help =
+  .help = Shows this message
+
+command-togglebalance-help =
+  .help = Toggle showing balance in shop.
+
+command-trade-help =
+  .help = Trade {-pokemon-plural} with another trainer.
+
+command-trade-remove-help =
+  .help = Remove {-pokemon-plural} from a trade.
+
+command-trade-remove-redeems-help =
+  .help = Remove redeems from a trade.
+
+command-trade-remove-pokecoins-help =
+  .help = Remove {-pokecoin-plural} from a trade.
+
+command-trade-add-help =
+  .help = Add {-pokemon-plural} to a trade.
+
+command-trade-add-pokecoins-help =
+  .help = Add {-pokecoin-plural} to a trade.
+
+command-trade-add-redeems-help =
+  .help = Add redeems to a trade.
+
+command-trade-cancel-help =
+  .help = Cancel a trade.
+
+command-trade-info-help =
+  .help = View a {-pokemon} from the trade.
+
+command-trade-confirm-help =
+  .help = Confirm a trade.
+
+command-trade-addall-help =
+  .help = Add multiple {-pokemon} to a trade.
+
+command-moveitem-help =
+  .help = Move a {-pokemon}'s held item.
+
+command-favorite-help =
+  .help = Mark a {-pokemon} as a favorite.
+
+command-unfavorite-help =
+  .help = Unfavorite a selected pokemon.
+
+command-balance-help =
+  .help = View your current balance.
+
+command-buy-help =
+  .help = Purchase an item from the shop.
+
+command-info-help =
+  .help = View a specific {-pokemon} from your collection.
+
+command-learn-help =
+  .help = Learn moves for your {-pokemon} to use in battle.
+
+command-redeemspawn-help =
+  .help = Use a redeem to spawn a {-pokemon} of your choice.
+
+command-silence-help =
+  .help = Silence level up messages for yourself.
+
+command-unfavoriteall-help =
+  .help = Mass unfavorite selected pokemon.
+
+command-quests-help =
+  .help = View quests.
+
+command-market-help =
+  .help = Buy or sell {-pokemon} on the {-brand} marketplace.
+
+command-market-search-help =
+  .help = Search {-pokemon} from the marketplace.
+
+command-market-add-help =
+  .help = List a {-pokemon} on the marketplace.
+
+command-market-remove-help =
+  .help = Remove a {-pokemon} from the marketplace.
+
+command-market-info-help =
+  .help = View a {-pokemon} from the market.
+
+command-market-buy-help =
+  .help = Buy a {-pokemon} on the marketplace.
+
+command-battle-help =
+  .help = Battle another trainer with your {-pokemon}!
+
+command-battle-cancel-help =
+  .help = Cancel a battle.
+
+command-battle-move-help =
+  .help = Move in a battle.
+
+command-battle-add-help =
+  .help = Add a {-pokemon} to a battle.
+
+command-shop-help =
+  .help = View the {-brand} item shop.
+
+command-releaseall-help =
+  .help = Mass release {-pokemon} from your collection for 2 pc each.
+
+command-hint-help =
+  .help = Get a hint for the wild {-pokemon}.
+
+command-nickall-help =
+  .help = Mass nickname {-pokemon} from your collection.
+
+command-moveset-help =
+  .help = View all moves for your {-pokemon} and how to get them.
+
+command-reindex-help =
+  .help = Re-number all {-pokemon} in your collection.
+
+command-moves-help =
+  .help = View current and available moves for your {-pokemon}.
+
+command-donate-help =
+  .help = Donate to receive shards.
+
+command-select-help =
+  .help = Select a specific {-pokemon} from your collection.
+
+command-serversilence-help =
+  .help = Silence level up messages server-wide.
+
+command-ping-help =
+  .help = View the bot's latency.
+
+command-order-help =
+  .help = Change how your {-pokemon} are ordered.
+
+command-vote-help =
+  .help = View information on voting rewards.
+
+command-admin-addbox-help =
+  .help = Give a user boxes.
+
+command-admin-tempsuspend-help =
+  .help = Temporarily uspend one or more users.
+
+command-admin-addcoins-help =
+  .help = Add to a user's balance.
+
+command-admin-setup-help =
+  .help = Test setup {-pokemon}.
+
+command-admin-addshard-help =
+  .help = Add to a user's shard balance.
+
+command-admin-give-help =
+  .help = Give a {-pokemon}.
+
+command-admin-unsuspend-help =
+  .help = Unuspend one or more users.
+
+command-admin-addredeem-help =
+  .help = Give a redeem.
+
+command-admin-addvote-help =
+  .help = Add to a user's vote streak.
+
+command-admin-suspend-help =
+  .help = Suspend one or more users.
+
+command-release-help =
+  .help = Release {-pokemon} from your collection for 2pc each.
+
+command-stats-help =
+  .help = View bot info.
+
+command-auction-help =
+  .help = Auction {-pokemon}.
+
+command-auction-bid-help =
+  .help = Bid on an auction.
+
+command-auction-info-help =
+  .help = View a {-pokemon} from an auction.
+
+command-auction-lowerstart-help =
+  .help = Lower the starting bid for your auction.
+
+command-auction-channel-help =
+  .help = Change the auctions channel.
+
+command-auction-search-help =
+  .help = Search {-pokemon} from auctions.
+
+command-auction-start-help =
+  .help = Start an auction.
+
+command-moveinfo-help =
+  .help = View information about a certain move.
+
+command-redirect-help =
+  .help = Redirect {-pokemon} catches to one or more channels.
+
+command-redirect-reset-help =
+  .help = Reset channel redirect.
+
+command-pokemon-help =
+  .help = View or filter the {-pokemon} in your collection.
+
+command-catch-help =
+  .help = Catch a wild {-pokemon}.
+
+command-togglemention-help =
+  .help = Toggle getting mentioned when catching a {-pokemon}.
+
+command-start-help =
+  .help = View the starter {-pokemon}.
+
+command-pokedex-help =
+  .help = View your pokédex, or search for a {-pokemon} species.
+
+command-pride-help =
+  .help = Pride Month 2023 event commands.
+
+command-pride-buddy-help =
+  .help = View your Pride Buddy.
+
+command-pride-offer-help =
+  .help = Offer flags to your Pride Buddy.
+
+command-evolve-help =
+  .help = Evolve a {-pokemon} if it has reached the target level.
+
+command-embedcolor-help =
+  .help = Change the embed colors for a {-pokemon}.
+
+command-pick-help =
+  .help = Pick a starter {-pokemon} to get started.
+
+command-dropitem-help =
+  .help = Drop a {-pokemon}'s held item.

--- a/lang/en-US/help.ftl
+++ b/lang/en-US/help.ftl
@@ -1,12 +1,4 @@
-### Localization for the help command, and commands in general
-
-## Localizations for commands and cogs.
-
-# Note: Currently unused because of a current technical limitation.
-command-help-help =
-  .help = Show help about the bot, a command, or a category.
-
-## Localization for help command-specific functionality.
+### Localization for the help command
 
 help-not-found = No help found…
 

--- a/lang/en-US/main.ftl
+++ b/lang/en-US/main.ftl
@@ -1,4 +1,9 @@
 -pokemon = Pokémon
+-pokemon-plural = Pokémon
+
+-pokecoin = Pokécoin
+-pokecoin-plural = Pokécoins
+
 -brand = Pokétwo
 
 -command-pick = {COMMAND("pick <pokemon>")}

--- a/lang/en-US/main.ftl
+++ b/lang/en-US/main.ftl
@@ -4,6 +4,8 @@
 -pokecoin = Pokécoin
 -pokecoin-plural = Pokécoins
 
+-pokedex = Pokédex
+
 -brand = Pokétwo
 
 -command-pick = {COMMAND("pick <pokemon>")}


### PR DESCRIPTION
Unfortunately, we can't do this:

```
-pokemon = Pokémon
  .plural = Pokémon
```

We can't seem to refer to `{-pokemon.plural}` inside of messages. You can only match on them inside of selectors. I'm not sure if this is even necessary, or the right thing to do when it comes to localizations 🤔 We might only know the right thing to do once we get more strings.