### PR TITLE
Allow the bot's assigned role to be used as prefix

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -51,8 +51,12 @@ CONCURRENCY_LIMITED_COMMANDS = {
 
 
 async def determine_prefix(bot, message):
-    return [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
+    prefixes = [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
+    # Allow the bot's assigned role on the guild as a prefix
+    if (guild := message.guild) and (role := guild.self_role):
+        prefixes.append(role.mention)
 
+    return prefixes
 
 class ClusterBot(commands.AutoShardedBot):
     class BlueEmbed(discord.Embed):


### PR DESCRIPTION
This PR fixes the problem of users mistakenly pinging the bot's assigned role instead of the bot and thinking it's a bug for not working, by making that role a prefix.

This only works because the bot is being pinged and hence receiving the message content.