### PR TITLE
Allow the bot's assigned role to be used as prefix

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,11 @@ CONCURRENCY_LIMITED_COMMANDS = {
 
 
 async def determine_prefix(bot, message):
-    return [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
+    prefixes = [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
+    if (guild := message.guild) and (role := guild.self_role):
+        prefixes.append(role.mention)
+
+    return prefixes 
 
 
 class ClusterBot(commands.AutoShardedBot):

--- a/bot.py
+++ b/bot.py
@@ -53,6 +53,7 @@ CONCURRENCY_LIMITED_COMMANDS = {
 
 async def determine_prefix(bot, message):
     prefixes = [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
+    # Allow the bot's assigned role as prefix if possible
     if (guild := message.guild) and (role := guild.self_role):
         prefixes.append(role.mention)
 


### PR DESCRIPTION
This PR fixes the problem of users mistakenly pinging the bot's assigned role instead of the bot and thinking it's a bug for not working, by making that role a prefix.

This only works because the bot is being pinged and hence receiving the message content.

New PR opened to master branch instead of production