### PR TITLE
Fix pokedex bug where you could go to pages beyond the shown pokemon

### DIFF
--- a/cogs/pokemon.py
+++ b/cogs/pokemon.py
@@ -1062,7 +1062,7 @@ class Pokemon(commands.Cog):
 
                 return embed
 
-            pages = pagination.ContinuablePages(pagination.FunctionPageSource(math.ceil(total_count / 20), get_page))
+            pages = pagination.ContinuablePages(pagination.FunctionPageSource(math.ceil(len(pokedex) / 20), get_page))
             pages.current_page = int(search_or_page) - 1
             self.bot.menus[ctx.author.id] = pages
             await pages.start(ctx)


### PR DESCRIPTION
This PR fixes a minor bug in the `pokedex` command that lets you go to pages beyond the shown list of pokemon. Causing it to not loop back when showing filtered results. This PR has been tested!
## Before fix
### 1. BACK at the first page does not loop back to the last
> ![Discord_QDLvRlFPK0](https://github.com/poketwo/poketwo/assets/81734495/afbb403d-340e-45e8-926e-d40d30afabac)
### 2. Pagination even with not enough results
> ![Discord_i7XI9bRvEg](https://github.com/poketwo/poketwo/assets/81734495/f309bdeb-ed66-40e7-b40d-4af32d91b33e)

## After fix (no emojis because personal instance)
### 1.
> ![Discord_63LvGvcWM9](https://github.com/poketwo/poketwo/assets/81734495/b8b574fe-f0f2-4c4c-b0d9-8c74ea67a5ac)
### 2. No pagination because end of results.
> ![Discord_c0V28qeXxj](https://github.com/poketwo/poketwo/assets/81734495/a013e799-26a8-4ab6-880b-30e71fa20282)