### PR TITLE
Battling bugfixes

### DIFF
--- a/cogs/battling.py
+++ b/cogs/battling.py
@@ -147,7 +147,7 @@ class Battle:
         for trainer in self.trainers:
             embed.add_field(
                 name=f"{trainer.user}'s Party",
-                value="\n".join(f"{x.iv_percentage:.2%} IV {x.species} ({x.idx + 1})" for x in trainer.pokemon),
+                value="\n".join(f"{x.iv_percentage:.2%} IV {x.species} ({x.idx})" for x in trainer.pokemon),
             )
 
         await self.channel.send(embed=embed)


### PR DESCRIPTION
### Bugfixes
- Fixed "Never misses" moves always missing
- Fixed recoil moves causing negative HP
- Fixed ailments causing negative HP
  - Added damage message for ailments
- Fixed long fractional values (such as 16.666666667 HP)
- Fixed it so that both pokemon have faint checks in the same round 
- Fixed pokemon index incrementing by 1 in the battle start embed