### PR TITLE
POK-222 Show market and auction listing ID in messages 

### DIFF
--- a/cogs/auctions.py
+++ b/cogs/auctions.py
@@ -270,7 +270,7 @@ class Auctions(commands.Cog):
         embed.timestamp = ends
 
         await auction_channel.send(embed=embed)
-        await ctx.send(f"Auctioning your **{pokemon.iv_percentage:.2%} {pokemon.species} No. {pokemon.idx}**.")
+        await ctx.send(f"Auctioning your **{pokemon.iv_percentage:.2%} {pokemon.species} No. {pokemon.idx}** (Auction #{counter['next']}).")
 
     @checks.has_started()
     @auction.command()

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -169,7 +169,7 @@ class Market(commands.Cog):
 
         await ctx.send(
             f"Listed your **{pokemon.iv_percentage:.2%} {pokemon.species} "
-            f"No. {pokemon.idx}** on the market for **{price:,}** Pokécoins."
+            f"No. {pokemon.idx}** on the market for **{price:,}** Pokécoins (Listing #{counter['next']})."
         )
 
     @checks.has_started()

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -283,13 +283,13 @@ class Market(commands.Cog):
 
         await self.bot.mongo.update_member(listing["owner_id"], {"$inc": {"balance": listing["market_data"]["price"]}})
         await ctx.send(
-            f"You purchased a **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}) for {listing['market_data']['price']} Pokécoins. Do `{ctx.clean_prefix}info latest` to view it!"
+            f"You purchased a **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}) for **{listing['market_data']['price']:,}** Pokécoins. Do `{ctx.clean_prefix}info latest` to view it!"
         )
 
         self.bot.loop.create_task(
             self.bot.send_dm(
                 listing["owner_id"],
-                f"Someone purchased your **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}). You received {listing['market_data']['price']:,} Pokécoins!",
+                f"Someone purchased your **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}). You received **{listing['market_data']['price']:,}** Pokécoins!",
             )
         )
 

--- a/cogs/market.py
+++ b/cogs/market.py
@@ -283,13 +283,13 @@ class Market(commands.Cog):
 
         await self.bot.mongo.update_member(listing["owner_id"], {"$inc": {"balance": listing["market_data"]["price"]}})
         await ctx.send(
-            f"You purchased a **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market for {listing['market_data']['price']} Pokécoins. Do `{ctx.clean_prefix}info latest` to view it!"
+            f"You purchased a **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}) for {listing['market_data']['price']} Pokécoins. Do `{ctx.clean_prefix}info latest` to view it!"
         )
 
         self.bot.loop.create_task(
             self.bot.send_dm(
                 listing["owner_id"],
-                f"Someone purchased your **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market. You received {listing['market_data']['price']:,} Pokécoins!",
+                f"Someone purchased your **{pokemon.iv_percentage:.2%} {pokemon.species}** from the market (Listing #{listing['market_data']['_id']}). You received {listing['market_data']['price']:,} Pokécoins!",
             )
         )
 


### PR DESCRIPTION
- Added Market and Auction listing IDs to sale confirmation messages
- Added Market listing ID to purchase and sale messages
- Fixed Pokécoins number formatting inconsistency

Note: This will cause merge conflicts with #562 