### PR TITLE
Remove attempted fix for role mention problem

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -54,9 +54,6 @@ CONCURRENCY_LIMITED_COMMANDS = {
 
 async def determine_prefix(bot, message):
     prefixes = [f"<@{bot.user.id}>", f"<@!{bot.user.id}>"]
-    # Allow the bot's assigned role as prefix if possible
-    if (guild := message.guild) and (role := guild.self_role):
-        prefixes.append(role.mention)
 
     return prefixes
 


### PR DESCRIPTION
This PR removes the attempted fix for the role mention problem that was added in the past, which added the assigned role mention to the list of prefixes. Unfortunately though, bots do not receive message content from role mentions, and hence it did not work.