### PR TITLE
Add daily quest progress tracking for Pokémon catching

### DIFF
--- a/cogs/dailyquest.py
+++ b/cogs/dailyquest.py
@@ -1,0 +1,72 @@
+import discord
+from discord.ext import commands
+import datetime
+import json
+import os
+
+PLAYER_DATA_PATH = "data/players.json"
+QUEST_LIST = [
+    {"type": "catch", "count": 3, "description": "Catch 3 different Pokémon"},
+]
+
+def load_data():
+    if os.path.exists(PLAYER_DATA_PATH):
+        with open(PLAYER_DATA_PATH, "r") as f:
+            return json.load(f)
+    return {}
+
+def save_data(data):
+    with open(PLAYER_DATA_PATH, "w") as f:
+        json.dump(data, f, indent=2)
+
+class Quests(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    def assign_daily_quest(self, user_id, data):
+        from random import choice
+        quest = choice(QUEST_LIST)
+        data[str(user_id)]["quest"] = {
+            "type": quest["type"],
+            "count": quest["count"],
+            "progress": 0,
+            "description": quest["description"],
+            "assigned": str(datetime.date.today())
+        }
+
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.author.bot:
+            return
+        user_id = message.author.id
+        data = load_data()
+        if str(user_id) not in data:
+            data[str(user_id)] = {}
+        user_data = data[str(user_id)]
+        today = str(datetime.date.today())
+
+        if "quest" not in user_data or user_data["quest"].get("assigned") != today:
+            self.assign_daily_quest(user_id, data)
+            save_data(data)
+
+    @commands.command(name="quest")
+    async def quest(self, ctx):
+        user_id = str(ctx.author.id)
+        data = load_data()
+        if user_id not in data or "quest" not in data[user_id]:
+            await ctx.send("No active quest found.")
+            return
+        quest = data[user_id]["quest"]
+        await ctx.send(f"📜 **Today's Quest:** {quest['description']}\nProgress: {quest['progress']}/{quest['count']}")
+
+    # Add the coins command
+    @commands.command(name="coins")
+    async def coins(self, ctx):
+        user_id = str(ctx.author.id)
+        data = load_data()
+        coins = data.get(user_id, {}).get("coins", 0)
+        await ctx.send(f"{ctx.author.mention} has {coins} coins.")
+
+
+def setup(bot):
+    bot.add_cog(Quests(bot))

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -285,6 +285,17 @@ class Spawning(commands.Cog):
     @commands.command(aliases=("c",))
     async def catch(self, ctx, *, guess: str):
         """Catch a wild pokémon."""
+        from data.players import load_data, save_data
+user_id = str(ctx.author.id)
+data = load_data()
+
+if user_id in data and "quest" in data[user_id]:
+    quest = data[user_id]["quest"]
+    if quest["type"] == "catch" and quest["progress"] < quest["count"]:
+        quest["progress"] += 1
+        if quest["progress"] == quest["count"]:
+            await ctx.send("🎉 You completed your daily quest! +100 coins awarded!")
+        save_data(data)
 
         # Retrieve correct species and level from tracker
 

--- a/cogs/spawning.py
+++ b/cogs/spawning.py
@@ -296,6 +296,13 @@ if user_id in data and "quest" in data[user_id]:
         if quest["progress"] == quest["count"]:
             await ctx.send("🎉 You completed your daily quest! +100 coins awarded!")
         save_data(data)
+                # Award coins
+            COIN_REWARD = 100
+            if "coins" not in data[user_id]:
+                data[user_id]["coins"] = 0
+            data[user_id]["coins"] += COIN_REWARD
+            save_data(data)
+            await ctx.send(f"{ctx.author.mention} has been awarded {COIN_REWARD} coins! 🎉")
 
         # Retrieve correct species and level from tracker
 


### PR DESCRIPTION
## Summary

This PR adds support for tracking progress of a "daily quest" when a user successfully catches a Pokémon. If the user completes the quest, they receive a reward and are notified in the same channel.

## Changes Made

- Added logic after a successful Pokémon catch (in spawning.py) to:
  - Check if the user has an active "catch" type quest.
  - Increment the quest's progress counter.
  - If the quest is completed, award 100 coins and notify the user.

- Uses the existing `load_data()` and `save_data()` functions from data.players.

## Example Behavior

- If a user has a quest like: `"type": "catch", "count": 3`, each catch increments `progress` by 1.
- On reaching 3 catches:
  - Message: 🎉 You completed your daily quest! +100 coins awarded!

## Motivation

This is part of a new "Daily Quests with Rewards" system being developed to improve user engagement and provide additional goals during gameplay.

## Notes

- This implementation assumes that the `data[user_id]["quest"]` structure is already created and managed elsewhere.
- Coin awarding is only displayed — actual coin addition logic can be implemented later or separately.

## Related Issues/Features

- Builds upon discussion around Daily Quests system.
- Could be extended with other quest types (e.g., duel, evolve) in future PRs.
-